### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-chatbot/security/code-scanning/3](https://github.com/RumenDamyanov/php-chatbot/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow (just below the `name` field), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to read repository contents but not write to them. This change does not affect the existing functionality of the workflow.

- Edit `.github/workflows/ci.yml`.
- Insert a `permissions:` block after the `name:` line and before the `on:` block.
- Set `contents: read` as the only permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
